### PR TITLE
Update `imetrics_http_server` module to use cowboy instead of `mod_esi`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 ebin
 *.swp
 _build
+.vscode

--- a/rebar.config
+++ b/rebar.config
@@ -1,3 +1,6 @@
 {erl_opts, [
     {platform_define, "R16", 'unsupported'}
 ]}.
+{deps, [
+    {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.8.0"}}}
+]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,12 @@
-[].
+[{<<"cowboy">>,
+  {git,"https://github.com/ninenines/cowboy.git",
+       {ref,"3eec447960eb03cde48f0f04cd72fd4d1e548ca0"}},
+  0},
+ {<<"cowlib">>,
+  {git,"https://github.com/ninenines/cowlib",
+       {ref,"1b5539a1da1d39b110d81b118000f00bbedaf4b4"}},
+  1},
+ {<<"ranch">>,
+  {git,"https://github.com/ninenines/ranch",
+       {ref,"3190aef88aea04d6dce8545fe9b4574288903f44"}},
+  1}].

--- a/src/imetrics.app.src
+++ b/src/imetrics.app.src
@@ -1,12 +1,12 @@
 {application, imetrics,
  [
-  {description, ""},
+  {description, "A lightweight library to allow you to easily instrument your Erlang libraries."},
   {vsn, "1"},
   {registered, []},
   {applications, [
                   kernel,
                   stdlib,
-                  inets
+                  cowboy
                  ]},
   {mod, { imetrics_app, []}},
   {env, []}

--- a/src/imetrics_http_server.erl
+++ b/src/imetrics_http_server.erl
@@ -6,16 +6,22 @@
 %% API Function Exports
 %% ------------------------------------------------------------------
 
--export([start_link/0, inets_pid/0, await/1, port/0]).
+-export([start_link/0, cowboy_pid/0, await/1, port/0]).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Exports
 %% ------------------------------------------------------------------
 
--export([init/1, handle_call/3, handle_cast/2, handle_info/2,
-         terminate/2, code_change/3]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3
+]).
 
--record(state, {inets_pid}).
+-record(state, {cowboy_pid, port}).
 
 %% ------------------------------------------------------------------
 %% API Function Definitions
@@ -32,25 +38,25 @@ await(Timeout) ->
 await(_, 0) ->
     {error, down};
 await(H, Steps) ->
-    case inets_pid() of
+    case cowboy_pid() of
         Pid when is_pid(Pid) ->
             ok;
         _ ->
             timer:sleep(H),
-            await(Steps-1)
+            await(Steps - 1)
     end.
 
 port() ->
-    case inets_pid() of
+    case cowboy_pid() of
         Pid when is_pid(Pid) ->
-            [{port, Port}] = httpd:info(Pid, [port]),
+            Port = gen_server:call(?SERVER, {port}, 5000),
             {ok, Port};
         Error ->
             Error
     end.
 
-inets_pid() ->
-    gen_server:call(?SERVER, {inets_pid}, 5000).
+cowboy_pid() ->
+    gen_server:call(?SERVER, {cowboy_pid}, 5000).
 
 %% ------------------------------------------------------------------
 %% gen_server Function Definitions
@@ -61,57 +67,50 @@ init(_Args) ->
     gen_server:cast(self(), {start}),
     {ok, #state{}}.
 
-handle_call({inets_pid}, _From, State=#state{inets_pid=Pid}) ->
-    {reply, Pid, State}.
-
-ensure_dir(Dir) ->
-    case file:make_dir(Dir) of
-        ok -> ok;
-        {error, eexist} -> ok;
-        Er -> Er
-    end.
+handle_call({cowboy_pid}, _From, State = #state{cowboy_pid = Pid}) ->
+    {reply, Pid, State};
+handle_call({port}, _From, State = #state{port = Port}) ->
+    {reply, Port, State}.
 
 handle_cast({start}, State) ->
-    StartRes = try
-        start_server()
-    catch Class:Reason ->
-        {error, {exception, Class, Reason}}
-    end,
+    Port = application:get_env(imetrics, http_server_port, 8085),
+    StartRes =
+        try
+            start_server(Port)
+        catch
+            Class:Reason ->
+                {error, {exception, Class, Reason}}
+        end,
     case StartRes of
         {ok, Pid} ->
-            {noreply, State#state{inets_pid=Pid}};
+            {noreply, State#state{cowboy_pid = Pid, port = Port}};
         Er ->
             % TODO - logging
             io:format("~p~n", [Er]),
             Self = self(),
             spawn(fun() ->
-                        timer:sleep(5000),
-                        gen_server:cast(Self, {start})
-                end),
+                timer:sleep(5000),
+                gen_server:cast(Self, {start})
+            end),
             {noreply, State}
     end.
 
-start_server() ->
-    Home = application:get_env(imetrics, http_home, "/tmp/imetrics"),
-    ServerRoot = application:get_env(imetrics, http_server_root, Home ++ "/server_root"),
-    DocumentRoot = application:get_env(imetrics, http_document_root, Home ++ "/document_root"),
-    ok = ensure_dir(Home),
-    ok = ensure_dir(ServerRoot),
-    ok = ensure_dir(DocumentRoot),
-    inets:start(httpd,
-               [{port, application:get_env(imetrics, http_server_port, 8085)},
-                {server_name, atom_to_list(?MODULE)},
-                {server_root, ServerRoot},
-                {document_root, DocumentRoot},
-                {bind_address, "localhost"},
-                {error_log_format, pretty},
-                {erl_script_alias, {"/imetrics", [varz]}}]).
+start_server(Port) ->
+    Dispatch = cowboy_router:compile([
+        % '_' here is a match for all domain names
+        {'_', [{"/imetrics/:func", varz, []}]}
+    ]),
+    cowboy:start_clear(
+        ?MODULE,
+        [{port, Port}],
+        #{env => #{dispatch => Dispatch}}
+    ).
 
 handle_info({'EXIT', _From, Reason}, State) ->
     {stop, Reason, State}.
 
-terminate(_Reason, _State=#state{inets_pid=Pid}) when is_pid(Pid) ->
-    inets:stop(httpd, Pid);
+terminate(_Reason, _State = #state{cowboy_pid = Pid}) when is_pid(Pid) ->
+    cowboy:stop_listener(?MODULE);
 terminate(_Reson, _State) ->
     ok.
 
@@ -121,4 +120,3 @@ code_change(_OldVsn, State, _Extra) ->
 %% ------------------------------------------------------------------
 %% Internal Function Definitions
 %% ------------------------------------------------------------------
-

--- a/src/varz.erl
+++ b/src/varz.erl
@@ -134,9 +134,9 @@ handle(Req, DataFun) ->
                 end
         end
     catch
-        Class:Reason ->
+        Class:Reason:Stacktrace ->
             io:format("exception ~p:~p~n", [Class, Reason]),
-            % io:format("~p~n", [erlang:get_stacktrace()]),
+            io:format("~p~n", [Stacktrace]),
             ok
     end.
 

--- a/src/varz.erl
+++ b/src/varz.erl
@@ -1,141 +1,172 @@
 -module(varz).
 
--export([get/3, counters/3, gauges/3, hist/3, hist_percentiles/3, slo/3]).
+-export([init/2, terminate/3]).
+-export([get/1, counters/1, gauges/1, hist/1, hist_percentiles/1, slo/1]).
 
--compile(nowarn_deprecated_function). % get_stacktrace
+% get_stacktrace
+-compile(nowarn_deprecated_function).
 
-get(SessionId, Headers, ReqBody) ->
-    handle(SessionId, Headers, ReqBody, fun imetrics:get/0).
+% cowboy functions:
+init(Req, State) ->
+    [<<"varz">>, FuncNameBinary] = string:split(cowboy_req:binding(func, Req), ":"),
+    FuncName = binary_to_atom(FuncNameBinary),
+    {ok, Req1} = ?MODULE:FuncName(Req),
+    {ok, Req1, State}.
+terminate(_Reason, _Req, _State) ->
+    ok.
 
-counters(SessionId, Headers, ReqBody) ->
-    handle(SessionId, Headers, ReqBody, fun imetrics:get_counters/0).
+get(Req) ->
+    handle(Req, fun imetrics:get/0).
 
-gauges(SessionId, Headers, ReqBody) ->
-    handle(SessionId, Headers, ReqBody, fun imetrics:get_gauges/0).
+counters(Req) ->
+    handle(Req, fun imetrics:get_counters/0).
 
-hist(SessionId, Headers, ReqBody) ->
-    handle(SessionId, Headers, ReqBody, fun imetrics:get_hist/0).
+gauges(Req) ->
+    handle(Req, fun imetrics:get_gauges/0).
 
-hist_percentiles(SessionId, Headers, ReqBody) ->
+hist(Req) ->
+    handle(Req, fun imetrics:get_hist/0).
+
+hist_percentiles(Req) ->
     % We create a resource key that's the combination of the user agent and the entire
     % query string. Note: this breaks HTTP conventions (namely GET should be idempotent)
-    QS = proplists:get_value(query_string, Headers, ""),
+    QS = cowboy_req:parse_qs(Req),
     K = qs_str_val(k, QS, ?MODULE_STRING),
     E = qs_e_val(QS),
-    Key = resource_key(K, Headers),
-    handle(SessionId, Headers, ReqBody,
-           fun() ->
-                   {Age, Data} = imetrics:get_hist_percentiles(Key, E),
-                   RespHeaders = ["Content-Type: text/plain\r\n",
-                                  "x-imetrics-interval-millis: ", integer_to_list(Age), "\r\n",
-                                  "\r\n"],
-                   {RespHeaders, Data}
-           end).
+    Key = resource_key(K, Req),
+    handle(
+        Req,
+        fun() ->
+            {Age, Data} = imetrics:get_hist_percentiles(Key, E),
+            RespHeaders = #{
+                <<"content-type">> => <<"text/plain">>,
+                <<"x-imetrics-interval-millis">> => [integer_to_list(Age)]
+            },
+            {RespHeaders, Data}
+        end
+    ).
 
-slo(SessionId, Headers, ReqBody) ->
-    QS = proplists:get_value(query_string, Headers, ""),
+slo(Req) ->
+    QS = cowboy_req:parse_qs(Req),
     case qs_atom_val(n, QS, ?MODULE_STRING) of
         UIdName when UIdName =/= ?MODULE_STRING ->
             case qs_str_val(u, QS, ?MODULE_STRING) of
                 ?MODULE_STRING ->
-                    handle(SessionId, Headers, ReqBody, fun(F, A) -> imetrics:foldl_slo(UIdName, F, A) end);
+                    handle(Req, fun(F, A) ->
+                        imetrics:foldl_slo(UIdName, F, A)
+                    end);
                 UId ->
-                    handle(SessionId, Headers, ReqBody, fun() -> imetrics:get_slo(UIdName, UId) end)
+                    handle(Req, fun() -> imetrics:get_slo(UIdName, UId) end)
             end
     end.
 
 qs_e_val(QS) ->
     Default = 1,
-    case re:run(QS, "e=(?<n>[1-9])", [{capture, [n], list}]) of
-        {match, [EStr]} ->
-            try list_to_integer(EStr)
-            catch _:_ ->
-                      Default
-            end;
-        _ ->
-            Default
+    Value = proplists:get_value(<<"e">>, QS),
+    case Value of
+        undefined ->
+            Default;
+        X ->
+            binary_to_integer(X)
     end.
 
 qs_atom_val(Name, QS, Default) ->
-    case qs_str_val(Name, QS, Default) of
-        Default ->
+    Value = proplists:get_value(atom_to_binary(Name, latin1), QS),
+    case Value of
+        undefined ->
             Default;
         X ->
-            list_to_atom(X)
+            binary_to_atom(X)
     end.
 
 qs_str_val(Name, QS, Default) ->
-    case re:run(QS, atom_to_list(Name)++"=(?<x>[^&]*)", [{capture, [x], list}]) of
-        {match, [KStr]} ->
-            KStr;
-        _ ->
-            Default
+    Value = proplists:get_value(atom_to_binary(Name, latin1), QS),
+    case Value of
+        undefined ->
+            Default;
+        X ->
+            binary_to_list(X)
     end.
 
-resource_key(K, Headers) ->
+resource_key(K, Req) ->
+    UserAgent = cowboy_req:header(<<"http_user_agent">>, Req, <<"default">>),
     iolist_to_binary([
-                      "imetrics_resource_key_",
-                      proplists:get_value(http_user_agent, Headers, ""),
-                      "_",
-                      K
-                     ]).
+        "imetrics_resource_key_",
+        UserAgent,
+        "_",
+        K
+    ]).
 
-handle(SessionId, _Headers, _ReqBody, DataFun) ->
+handle(Req, DataFun) ->
     try
         case erlang:fun_info(DataFun, arity) of
             {arity, 2} ->
                 %% Stream
-                RespHeaders = "Content-Type: text/plain\r\n\r\n",
-                mod_esi:deliver(SessionId, RespHeaders),
-                DataFun(fun(Data, Acc0) ->
-                                deliver_data(SessionId, [Data]),
-                                Acc0+1
-                        end,
-                        0);
+                Req1 = cowboy_req:set_resp_header(<<"content-type">>, "text/plain", Req),
+                Req2 = cowboy_req:stream_reply(200, Req1),
+                DataFun(
+                    fun(Data, Acc0) ->
+                        deliver_data(Req2, [Data]),
+                        Acc0 + 1
+                    end,
+                    0
+                ),
+                cowboy_req:stream_trailers(#{}, Req2),
+                {ok, Req2};
             {arity, 0} ->
                 %% Dump
                 case DataFun() of
                     [] ->
-                        RespHeaders = "Content-Type: text/plain\r\n\r\n",
-                        mod_esi:deliver(SessionId, RespHeaders),
-                        mod_esi:deliver(SessionId, "\n");
+                        Req1 = cowboy_req:set_resp_header(<<"content-type">>, "text/plain", Req),
+                        {ok, cowboy_req:reply(200, Req1)};
                     {DataHeaders, Data} ->
-                        mod_esi:deliver(SessionId, DataHeaders),
-                        deliver_data(SessionId, Data);
+                        Req1 = cowboy_req:set_resp_headers(DataHeaders, Req),
+                        Req2 = cowboy_req:stream_reply(200, Req1),
+                        deliver_data(Req2, Data),
+                        cowboy_req:stream_trailers(#{}, Req2),
+                        {ok, Req2};
                     Data ->
-                        RespHeaders = "Content-Type: text/plain\r\n\r\n",
-                        mod_esi:deliver(SessionId, RespHeaders),
-                        deliver_data(SessionId, Data)
+                        Req1 = cowboy_req:set_resp_header(<<"content-type">>, "text/plain", Req),
+                        Req2 = cowboy_req:stream_reply(200, Req1),
+                        deliver_data(Req2, Data),
+                        cowboy_req:stream_trailers(#{}, Req2),
+                        {ok, Req2}
                 end
         end
-    catch Class:Reason ->
-        io:format("exception ~p:~p~n", [Class, Reason]),
-        io:format("~p~n", [erlang:get_stacktrace()]),
-        ok
+    catch
+        Class:Reason ->
+            io:format("exception ~p:~p~n", [Class, Reason]),
+            % io:format("~p~n", [erlang:get_stacktrace()]),
+            ok
     end.
 
-deliver_data(SessionId, Data) ->
+deliver_data(Req, Data) ->
     lists:foreach(
         fun
             ({Name, Value}) when is_number(Value) ->
                 VStr = strnum(Value),
-                mod_esi:deliver(SessionId, [<<Name/binary, " ">>, VStr, "\n"]);
+                cowboy_req:stream_body([<<Name/binary, " ">>, VStr, "\n"], nofin, Req);
             ({Name, Map}) when is_map(Map) ->
                 MIo = serialize_proplist(maps:to_list(Map)),
-                mod_esi:deliver(SessionId, [<<Name/binary, " ">>, MIo, "\n"]);
+                cowboy_req:stream_body([<<Name/binary, " ">>, MIo, "\n"], nofin, Req);
             ({Name, MappedValues}) when is_list(MappedValues) ->
                 MIo = serialize_proplist(MappedValues),
-                mod_esi:deliver(SessionId, [<<Name/binary, " ">>, MIo, "\n"])
-        end, Data).
+                cowboy_req:stream_body([<<Name/binary, " ">>, MIo, "\n"], nofin, Req)
+        end,
+        Data
+    ).
 
 serialize_proplist(List) ->
     MIo = lists:map(
-            fun({Key= <<"$dim">>, VStr}) ->
-                    [Key, ":", VStr];
-               ({Key, Value}) when is_number(Value); Value =:= 'NaN' ->
-                    VStr = strnum(Value),
-                    [Key, ":", VStr]
-            end, List),
+        fun
+            ({Key = <<"$dim">>, VStr}) ->
+                [Key, ":", VStr];
+            ({Key, Value}) when is_number(Value); Value =:= 'NaN' ->
+                VStr = strnum(Value),
+                [Key, ":", VStr]
+        end,
+        List
+    ),
     string:join(MIo, " ").
 
 strnum('NaN') -> "NaN";

--- a/test/imetrics_hist_tests.erl
+++ b/test/imetrics_hist_tests.erl
@@ -2,12 +2,10 @@
 -include_lib("eunit/include/eunit.hrl").
 
 start() ->
-    application:start(inets),
-    application:start(imetrics).
+    application:ensure_all_started(imetrics).
 
 stop(_Fixture) ->
-    application:stop(imetrics),
-    application:stop(inets).
+    application:stop(imetrics).
 
 compute_bucket_test_() ->
     Tests = [

--- a/test/imetrics_slo_tests.erl
+++ b/test/imetrics_slo_tests.erl
@@ -3,13 +3,11 @@
 
 start() ->
     application:load(imetrics),
-    application:start(inets),
-    application:start(imetrics),
+    application:ensure_all_started(imetrics),
     {ok, _} = imetrics:register_slo(eunit, #{size => 128, hwm => 1024*100}).
 
 stop(_Fixture) ->
-    application:stop(imetrics),
-    application:stop(inets).
+    application:stop(imetrics).
 
 %% add tests
 slo_test_() ->

--- a/test/imetrics_tests.erl
+++ b/test/imetrics_tests.erl
@@ -3,14 +3,12 @@
 
 start() ->
     application:load(imetrics),
-    application:set_env(imetrics, http_server_port, 0),
-    application:start(inets),
-    application:start(imetrics),
+    application:set_env(imetrics, http_server_port, 8086),
+    application:ensure_all_started(imetrics),
     #{}.
 
 stop(_Fixture) ->
-    application:stop(imetrics),
-    application:stop(inets).
+    application:stop(imetrics).
 
 %% add tests
 add_test_() ->


### PR DESCRIPTION
In order to extend imetrics to support additional metric retrieval protocols, (such as [OpenMetrics](https://openmetrics.io/), which requires specific behavior related to URI paths that `mod_esi` does not support,) this PR updates the `imetrics_http_server` module to use [Cowboy](https://ninenines.eu/docs/en/cowboy/2.8/guide/) instead of Erlang's built-in `mod_esi` module.

- Full compatibility with original URL patterns has been maintained, at least in the short term
- Tests have been updated minimally, and all pass locally on my machine.
  - (The updates were necessary to assign a specific port when running the HTTP server for testing rather than picking a random port, which is a behavior that `mod_esi` supports that `cowboy` does not.)
- The README has been updated to remove references to `mod_esi`
- Unrelated to the main subject of this PR: Syntax highlighting in the README has been updated to properly highlight Erlang code snippets