### PR TITLE
Add `openmetrics_strict_compat` application env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,11 @@ cpu_load_avg 1min:0.1 5min:3.4
 Configuration
 -------------
 
-| env var            | default   | desc                                                        |
-| ------------------ | --------- | ----------------------------------------------------------- |
-| `http_server_port` | `8085`    | Listening port                                              |
-| `separator`        | `<<"_">>` | binary string used to separate tuple elements for Name, Key |
+| env var                     | default   | desc                                                         |
+| --------------------------- | --------- | ------------------------------------------------------------ |
+| `http_server_port`          | `8085`    | Listening port                                               |
+| `separator`                 | `<<"_">>` | binary string used to separate tuple elements for Name, Key  |
+| `strict_openmetrics_compat` | `false`   | If set to `true`, metrics will only display on the old HTTP endpoint if they aren't compatible with the OpenMetrics endpoint. Metrics will only display on one endpoint or the other, never both. |
 
 ## OpenMetrics conversion
 

--- a/openmetrics.md
+++ b/openmetrics.md
@@ -15,6 +15,7 @@
   - [x] Update handling of mapped data to convert mapped counters and stats maps to tagged metric sets
   - [ ] Metric type for stats
 - [x] Convert from `mod_esi` to `cowboy` to surface data at `/metrics` URL path (required by the standard)
+- [x] Add `openmetrics_strict_compat` application environment variable (causes only forwards-incompatible metrics to exist on the legacy endpoint and not exist on the OpenMetrics endpoint)
 - [ ] Extend `imetrics` to support additional OpenMetrics features
   - [ ] Exemplars
   - [ ] `UNIT` metric descriptor

--- a/src/imetrics.erl
+++ b/src/imetrics.erl
@@ -240,7 +240,17 @@ stop_tick_s(Ticks, RefOrName) ->
     end.
 
 get() ->
-    [Metric || {_, Metric} <- get_with_types()].
+    case application:get_env(imetrics, strict_openmetrics_compat, false) of
+        false ->
+            [Metric || {_, Metric} <- get_with_types()];
+        true ->
+            [
+                Metric
+             || {Type, Metric} <- get_with_types(),
+                not ((Type =:= counter) or (Type =:= gauge) or (Type =:= mapped_counter) or
+                    (Type =:= mapped_gauge))
+            ]
+    end.
 
 get_with_types() ->
     Counters = [{counter, Metric} || Metric <- get_unmapped(imetrics_counters)],

--- a/src/imetrics.erl
+++ b/src/imetrics.erl
@@ -240,17 +240,7 @@ stop_tick_s(Ticks, RefOrName) ->
     end.
 
 get() ->
-    case application:get_env(imetrics, strict_openmetrics_compat, false) of
-        false ->
-            [Metric || {_, Metric} <- get_with_types()];
-        true ->
-            [
-                Metric
-             || {Type, Metric} <- get_with_types(),
-                not ((Type =:= counter) or (Type =:= gauge) or (Type =:= mapped_counter) or
-                    (Type =:= mapped_gauge))
-            ]
-    end.
+    [Metric || {_, Metric} <- get_with_types()].
 
 get_with_types() ->
     Counters = [{counter, Metric} || Metric <- get_unmapped(imetrics_counters)],

--- a/src/varz.erl
+++ b/src/varz.erl
@@ -13,7 +13,19 @@ terminate(_Reason, _Req, _State) ->
     ok.
 
 get(Req) ->
-    handle(Req, fun imetrics:get/0).
+    case application:get_env(imetrics, strict_openmetrics_compat, false) of
+        false ->
+            handle(Req, fun imetrics:get/0);
+        true ->
+            handle(Req, fun() ->
+                [
+                    Metric
+                 || {Type, Metric} <- imetrics:get_with_types(),
+                    not ((Type =:= counter) or (Type =:= gauge) or (Type =:= mapped_counter) or
+                        (Type =:= mapped_gauge))
+                ]
+            end)
+    end.
 
 counters(Req) ->
     case application:get_env(imetrics, strict_openmetrics_compat, false) of

--- a/src/varz.erl
+++ b/src/varz.erl
@@ -16,10 +16,16 @@ get(Req) ->
     handle(Req, fun imetrics:get/0).
 
 counters(Req) ->
-    handle(Req, fun imetrics:get_counters/0).
+    case application:get_env(imetrics, strict_openmetrics_compat, false) of
+        false -> handle(Req, fun imetrics:get_counters/0);
+        true -> {ok, Req}
+    end.
 
 gauges(Req) ->
-    handle(Req, fun imetrics:get_gauges/0).
+    case application:get_env(imetrics, strict_openmetrics_compat, false) of
+        false -> handle(Req, fun imetrics:get_gauges/0);
+        true -> {ok, Req}
+    end.
 
 hist(Req) ->
     handle(Req, fun imetrics:get_hist/0).


### PR DESCRIPTION
For users attempting to make a graceful conversion from the old data format (`/imetrics/varz:get`) to the new format (`/metrics`), it's now possible to set the `openmetrics_strict_compat` environment variable. When this variable is set to `true`, the following behavior changes will occur:

1. Metric types that **are** currently fully supported in the `openmetrics` module, (currently counters, gauges, and their mapped equivalents,) will no longer be surfaced via the old interface in the `varz` module
2. Metric types that **are not** fully supported in the `openmetrics` module will not be surfaced at the new URL, only at the old interface.

When this variable is set to `false`, metrics will display in both places (unsupported metric types are of type `unknown` in OpenMetrics) which may be undesirable in terms of managing storage usage if monitoring systems are ingesting data from both endpoints.