### PR TITLE
Create imetrics_cowboy module

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ is_tuple(V) andalso tuple_size(V) =< 8
 Otherwise, the add and set_gauge functions will return
 `{error, {function_clause, check_inputs}}`.
 
+Automatic data collectors
+-------------------------
+
+imetrics also includes adapters for common Erlang modules to enable collection of
+certain metrics automatically. Further documentation for these modules is available
+below:
+
+- **imetrics_cowboy** - An imetrics adapter that collects information about Cowboy response handlers
+  and can also annotate metrics with custom user data [_(docs)_](docs/imetrics_cowboy.md)
+- **imetrics_cowboy_stream_h** - An older adapter for Cowboy that doesn't collect any custom user data
+  _(docs TBD)_
+- **imetrics_lager_backend** - A [Lager](https://github.com/erlang-lager/lager) backend that counts log
+  events segmented by log level _(docs TBD)_
+
 Retrieving data
 ---------------
 

--- a/docs/imetrics_cowboy.md
+++ b/docs/imetrics_cowboy.md
@@ -1,0 +1,48 @@
+# imetrics_cowboy
+
+The `imetrics_cowboy` module keeps track of metrics related to HTTP requests and
+responses made through the Cowboy web server. It makes use of the [`cowboy_metrics_h` stream handler](https://ninenines.eu/docs/en/cowboy/2.8/manual/cowboy_metrics_h/),
+which is included with Cowboy itself. It is configured in the call to `cowboy:start_clear/3`,
+or `cowboy:start_tls/3` as such:
+
+```erlang
+Dispatch = cowboy_router:compile([ ... ]),
+cowboy:start_clear(
+    HandlerModule,
+    [{port, Port}],
+    #{
+        % your router configuration:
+        env => #{dispatch => Dispatch},
+
+        % additional ProtocolOpts configurations
+        % ...
+
+        % make sure to include `cowboy_stream_h` as the last stream handler
+        stream_handlers => [cowboy_metrics_h, cowboy_stream_h],
+        metrics_callback => fun imetrics_cowboy:metrics_callback/1
+    }
+)
+```
+
+Once you've done this, the following counters will be automatically populated:
+
+-   `cowboy_responses` - the number of responses. Tagged with `code="{HTTP_STATUS_CODE}"`
+-   `cowboy_error_responses` - the number of responses with an HTTP 4XX or 5XX error code. Tagged the same as above.
+
+## Custom tags
+
+You can also provide custom tags for your metrics, by using the `imetrics_cowboy:add_tag/3`
+and `imetrics_cowboy:add_tags/2` functions. For example, if you'd like to tag the handler
+responsible for handling a specific request, just call:
+
+```erlang
+imetrics_cowboy:add_tag(Req, handler, handler_name_here),
+% or
+imetrics_cowboy:add_tags(Req, #{ handler => handler_name_here }).
+```
+
+## Ignoring certain requests
+
+If one particular endpoint is requested frequently, you can ignore those requests by calling
+`imetrics_cowboy:ignore_request(Req)`. This will cause that request to be entirely ignored by
+the metrics callback.

--- a/docs/imetrics_cowboy.md
+++ b/docs/imetrics_cowboy.md
@@ -27,7 +27,10 @@ cowboy:start_clear(
 Once you've done this, the following counters will be automatically populated:
 
 -   `cowboy_responses` - the number of responses. Tagged with `code="{HTTP_STATUS_CODE}"`
--   `cowboy_error_responses` - the number of responses with an HTTP 4XX or 5XX error code. Tagged the same as above.
+-   `cowboy_error_responses` - the number of responses where the cowboy handler encountered an error. Tagged with:
+    -   `code="{HTTP_STATUS_CODE}"`
+    -   `reason="{REASON}"` where **REASON** is one of `[internal_error, socket_error, stream_error, connection_error, stop]`
+        [(see `cowboy_stream`'s `reason()` type)](https://ninenines.eu/docs/en/cowboy/2.8/manual/cowboy_stream/#_reason)
 
 ## Custom tags
 

--- a/src/imetrics_cowboy.erl
+++ b/src/imetrics_cowboy.erl
@@ -20,9 +20,12 @@ metrics_callback(Metrics) ->
     },
     NewTags = maps:merge(SanitizedUserData, Tags),
 
-    case StatusCode >= 400 of
-        true -> imetrics:add(cowboy_error_responses_metric(), NewTags);
-        false -> false
+    case maps:get(reason, Metrics) of
+        normal -> ok;
+        switch_protocol -> ok;
+        Tuple when is_tuple(Tuple) ->
+            Reason = element(1, Tuple),
+            imetrics:add(cowboy_error_responses_metric(), NewTags#{ reason => imetrics_utils:bin(Reason) })
     end,
 
     imetrics:add(cowboy_responses_metric(), NewTags).

--- a/src/imetrics_cowboy.erl
+++ b/src/imetrics_cowboy.erl
@@ -1,0 +1,43 @@
+-module(imetrics_cowboy).
+
+-export([metrics_callback/1, add_tag/3, add_tags/2, ignore_request/1]).
+
+cowboy_responses_metric() ->
+    application:get_env(imetrics, cowboy_responses_metric, cowboy_responses).
+
+cowboy_error_responses_metric() ->
+    application:get_env(imetrics, cowboy_error_responses_metric, cowboy_error_responses).
+
+metrics_callback(#{user_data := #{'_imetrics_ignore_request' := true}}) ->
+    ignore_request;
+metrics_callback(Metrics) ->
+    StatusCode = maps:get(resp_status, Metrics),
+    UserData = maps:get(user_data, Metrics, #{}),
+
+    SanitizedUserData = maps:remove('_imetrics_ignore_request', UserData),
+    Tags = #{
+        code => imetrics_utils:bin(StatusCode)
+    },
+    NewTags = maps:merge(SanitizedUserData, Tags),
+
+    case StatusCode >= 400 of
+        true -> imetrics:add(cowboy_error_responses_metric(), NewTags);
+        false -> false
+    end,
+
+    imetrics:add(cowboy_responses_metric(), NewTags).
+
+add_tag(Req, Name, Value) when is_atom(Name) ->
+    cowboy_req:cast(
+        {set_options, #{metrics_user_data => #{Name => imetrics_utils:bin(Value)}}}, Req
+    ),
+    Req.
+
+add_tags(Req, Tags) when is_map(Tags) ->
+    maps:fold(fun(Name, Value, Acc) -> add_tag(Acc, Name, Value) end, Req, Tags).
+
+ignore_request(Req) ->
+    cowboy_req:cast(
+        {set_options, #{metrics_user_data => #{'_imetrics_ignore_request' => true}}}, Req
+    ),
+    Req.


### PR DESCRIPTION
Adds a new method of collecting cowboy requests using the [`cowboy_metrics_h` stream handler](https://ninenines.eu/docs/en/cowboy/2.8/manual/cowboy_metrics_h/).

~~**One possible regression with this new approach:** I believe that all 4XX / 5XX errors (even those intentionally emitted by users) will be picked up in this new implementation of the `cowboy_error_responses` metric, while I believe [the previous implementation](https://github.com/relaypro-open/imetrics/blob/494fafb2bd2e62412c50ab8ac2d33b865bbcce06/src/imetrics_cowboy_stream_h.erl#L78-L81) only triggers that metric when a crash occurs _or_ a handler exits with a `{request_error, ...}` tuple (See [this section of `cowboy_stream_h`](https://github.com/ninenines/cowboy/blob/2a082504996afccf78185182cd168123800bd4f0/src/cowboy_stream_h.erl#L129-L156) where the `{error_response, ...}` tuple seems to be generated.)~~

~~Is this acceptable, or should we narrow this metric to remain entirely identical to the metric surfaced by the legacy cowboy integration?~~

**Edit:** the above comment is out of date. See [below](#issuecomment-1068055073).