### PR TITLE
Fix a backwards incompatibility in the varz module

### DIFF
--- a/src/varz.erl
+++ b/src/varz.erl
@@ -176,14 +176,21 @@ serialize_proplist(List) ->
     MIo = lists:map(
         fun
             ({Key = <<"$dim">>, VStr}) ->
-                [Key, ":", VStr];
+                skip_dim;
             ({Key, Value}) when is_number(Value); Value =:= 'NaN' ->
                 VStr = strnum(Value),
                 [Key, ":", VStr]
         end,
         List
     ),
-    string:join(MIo, " ").
+    MIo2 = lists:filter(
+        fun
+            (skip_dim) -> false;
+            (_) -> true
+        end,
+        MIo
+    ),
+    string:join(MIo2, " ").
 
 serialize_dim_if_exists(Name) ->
     Results = ets:lookup(imetrics_map_keys, Name),

--- a/src/varz.erl
+++ b/src/varz.erl
@@ -173,24 +173,17 @@ deliver_data(Req, Data) ->
     ).
 
 serialize_proplist(List) ->
-    MIo = lists:map(
+    MIo = lists:filtermap(
         fun
-            ({Key = <<"$dim">>, VStr}) ->
-                skip_dim;
+            ({_Key = <<"$dim">>, _VStr}) ->
+                false;
             ({Key, Value}) when is_number(Value); Value =:= 'NaN' ->
                 VStr = strnum(Value),
-                [Key, ":", VStr]
+                {true, [Key, ":", VStr]}
         end,
         List
     ),
-    MIo2 = lists:filter(
-        fun
-            (skip_dim) -> false;
-            (_) -> true
-        end,
-        MIo
-    ),
-    string:join(MIo2, " ").
+    string:join(MIo, " ").
 
 serialize_dim_if_exists(Name) ->
     Results = ets:lookup(imetrics_map_keys, Name),


### PR DESCRIPTION
Fixes for:
- Dimension would be printed twice on calls to the `varz:counters` and `varz:gauges` endpoints
- Dimension would be printed when set to its default value (`map_key`) (it should not have been)

We don't have any test coverage for the legacy counters and gauges endpoints, I will need to write some soon.