### PR TITLE
Adds the `imetrics_vm_metrics` module

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,6 +2,7 @@
     {platform_define, "R16", 'unsupported'}
 ]}.
 {deps, [
-    {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.8.0"}}}
+    {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.8.0"}}},
+    {recon, {git, "https://github.com/ferd/recon.git", {tag, "2.5.1"}}}
 ]}.
 {shell, [{apps, [imetrics]}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -9,4 +9,8 @@
  {<<"ranch">>,
   {git,"https://github.com/ninenines/ranch",
        {ref,"3190aef88aea04d6dce8545fe9b4574288903f44"}},
-  1}].
+  1},
+ {<<"recon">>,
+  {git,"https://github.com/ferd/recon.git",
+       {ref,"f7b6c08e6e9e2219db58bfb012c58c178822e01e"}},
+  0}].

--- a/src/imetrics_ets_owner.erl
+++ b/src/imetrics_ets_owner.erl
@@ -33,6 +33,7 @@ init([]) ->
     ets:new(imetrics_stats, [public, named_table]),
     ets:new(imetrics_data_checkpoint, [public, named_table]),
     ets:new(imetrics_hist, [public, named_table]),
+    ets:new(imetrics_vm_metrics, [public, named_table]),
 
     ExpireCheckpointIntervalHr = application:get_env(imetrics, expire_checkpoint_interval_hr, 1),
     timer:apply_interval(timer:hours(ExpireCheckpointIntervalHr),

--- a/src/imetrics_vm_metrics.erl
+++ b/src/imetrics_vm_metrics.erl
@@ -1,0 +1,65 @@
+-module(imetrics_vm_metrics).
+-export([install/0, proc_count/2]).
+
+install() ->
+    imetrics:set_multigauge(erlang_vm, vm_metric, fun metric_fun/0).
+
+metric_fun() ->
+    LastUpdateTime = case ets:lookup(imetrics_vm_metrics, last_update_time) of
+        [{last_update_time, T}] -> T;
+        [] -> {0,0,0}
+    end,
+
+    Table = case (timer:now_diff(erlang:timestamp(), LastUpdateTime) div 1000) > timer:seconds(55) of
+        true ->
+            [
+                [{_MaxMQueuePid, MaxMQueueLen, _}|_],
+                [{_MaxMemoryPid, MaxMemory, _}|_]
+            ] = proc_count([
+                message_queue_len,
+                memory
+            ], 1),
+            Objects = [
+                {max_message_queue_len, MaxMQueueLen},
+                {max_memory, MaxMemory},
+                {atom_count, erlang:system_info(atom_count)},
+                {atom_limit, erlang:system_info(atom_limit)},
+                {last_update_time, erlang:timestamp()}
+            ],
+            ets:insert(imetrics_vm_metrics, Objects),
+            Objects;
+        false ->
+            ets:tab2list(imetrics_vm_metrics)
+    end,
+
+    Metrics = lists:keydelete(last_update_time, 1, Table),
+    Metrics.
+
+% A modification of recon:proc_count that allows you to fetch multiple
+% attributes without calling process_info multiple times.
+proc_count(AttrList, Num) ->
+    ProcInfos = proc_attrs(AttrList),
+    ProcInfosByAttr = lists:foldl(fun (ProcInfo, ProcInfosByAttr) ->
+        {Pid, Results, Info} = ProcInfo,
+        [[{Pid, AttrValue, Info}|AttrResultsList] || {AttrResultsList, {_AttrName, AttrValue}} <- lists:zip(ProcInfosByAttr, Results)]
+    end, [[] || _ <- AttrList], ProcInfos),
+    [recon_lib:sublist_top_n_attrs(AttrResultsList, Num) || AttrResultsList <- ProcInfosByAttr].
+
+% modified from recon
+% https://github.com/ferd/recon/blob/9efec263d84d0435230f4d3312a4afb352b8f71c/src/recon_lib.erl#L78
+proc_attrs(AttrList) ->
+    Self = self(),
+    FullAttrList = [registered_name, current_function, initial_call] ++ AttrList,
+    [Attrs || Pid <- processes(),
+              Pid =/= Self,
+              {ok, Attrs} <- [proc_attrs(FullAttrList, Pid)]
+    ].
+
+% https://github.com/ferd/recon/blob/9efec263d84d0435230f4d3312a4afb352b8f71c/src/recon_lib.erl#L100
+proc_attrs(AttrList, Pid) ->
+    case process_info(Pid, AttrList) of
+        [{registered_name,Name}, Init, Cur|Results] ->
+            {ok, {Pid, Results, [Name || is_atom(Name)]++[Init, Cur]}};
+        undefined ->
+            {error, undefined}
+    end.


### PR DESCRIPTION
- Requires recon as a dependency for its process heap implementation
- Adds a new `imetrics_vm_metrics` ETS table
- Updates VM metrics at most once per minute:
  - max message queue length
  - max process memory
  - atom count
  - system atom limit
- contains a reimplementation of recon functionality to fetch multiple process attributes at the same time