### PR TITLE
Allow name as a tag for exemplars

### DIFF
--- a/src/imetrics.erl
+++ b/src/imetrics.erl
@@ -76,7 +76,7 @@ set_exemplar(Name, Tags, EValue, Labels, Timestamp) ->
     ?CATCH_KNOWN_EXC(
         begin
             BinList = imetrics_utils:bin(Labels),
-            TagsWithName = imetrics_utils:bin(Tags#{ name => Name }),
+            TagsWithName = imetrics_utils:bin(Tags#{ <<"__name__">> => Name }),
             ets:insert(imetrics_exemplars, {TagsWithName, EValue, BinList, Timestamp})
         end
     ).

--- a/src/imetrics.erl
+++ b/src/imetrics.erl
@@ -76,7 +76,7 @@ set_exemplar(Name, Tags, EValue, Labels, Timestamp) ->
     ?CATCH_KNOWN_EXC(
         begin
             BinList = imetrics_utils:bin(Labels),
-            TagsWithName = imetrics_utils:bin(Tags#{ <<"__name__">> => Name }),
+            TagsWithName = imetrics_utils:bin(Tags#{ '__name__' => Name }),
             ets:insert(imetrics_exemplars, {TagsWithName, EValue, BinList, Timestamp})
         end
     ).

--- a/src/openmetrics.erl
+++ b/src/openmetrics.erl
@@ -68,7 +68,7 @@ deliver_metricfamily(Req, {Name, {Type, MetricValue}}) ->
 get_exemplar_string(Name) ->
     get_exemplar_string(Name, #{}).
 get_exemplar_string(Name, Tags) ->
-    TagsWithName = imetrics_utils:bin(Tags#{ name => Name }),
+    TagsWithName = imetrics_utils:bin(Tags#{ <<"__name__">> => Name }),
     case imetrics:get_exemplar(TagsWithName) of
         {EValue, Labels, Timestamp} ->
             EStr = strnum(EValue),

--- a/src/openmetrics.erl
+++ b/src/openmetrics.erl
@@ -68,7 +68,7 @@ deliver_metricfamily(Req, {Name, {Type, MetricValue}}) ->
 get_exemplar_string(Name) ->
     get_exemplar_string(Name, #{}).
 get_exemplar_string(Name, Tags) ->
-    TagsWithName = imetrics_utils:bin(Tags#{ <<"__name__">> => Name }),
+    TagsWithName = imetrics_utils:bin(Tags#{ '__name__' => Name }),
     case imetrics:get_exemplar(TagsWithName) of
         {EValue, Labels, Timestamp} ->
             EStr = strnum(EValue),

--- a/test/imetrics_tests.erl
+++ b/test/imetrics_tests.erl
@@ -126,25 +126,25 @@ exemplar_test(_Fixture) ->
     imetrics:set_exemplar(l, #{name => "test1"}, 1),
     imetrics:set_exemplar(l, #{name => "test2"}, 2),
 
-    ?_assertMatch({1, #{}, _}, imetrics:get_exemplar(#{<<"__name__">> => <<"a">>})),
-    ?_assertMatch({2, #{}, _}, imetrics:get_exemplar(#{<<"__name__">> => <<"b">>, c => <<"1">>})),
+    ?_assertMatch({1, #{}, _}, imetrics:get_exemplar(#{'__name__' => <<"a">>})),
+    ?_assertMatch({2, #{}, _}, imetrics:get_exemplar(#{'__name__' => <<"b">>, c => <<"1">>})),
     Test3Map = #{d => <<"2">>, e => <<"aa">>},
-    ?_assertMatch({2, Test3Map, _}, imetrics:get_exemplar(#{<<"__name__">> => <<"c">>})),
-    ?_assertMatch({3, #{}, 946684800}, imetrics:get_exemplar(#{<<"__name__">> => <<"f">>})),
+    ?_assertMatch({2, Test3Map, _}, imetrics:get_exemplar(#{'__name__' => <<"c">>})),
+    ?_assertMatch({3, #{}, 946684800}, imetrics:get_exemplar(#{'__name__' => <<"f">>})),
     Test5Map = #{j => <<"k">>},
-    ?_assertMatch({3, Test5Map, _}, imetrics:get_exemplar(#{<<"__name__">> => <<"g">>, h => <<"1">>, i => <<"2">>})),
-    ?_assertMatch({4, #{}, 978307200}, imetrics:get_exemplar(#{<<"__name__">> => <<"g">>, h => <<"2">>})),
+    ?_assertMatch({3, Test5Map, _}, imetrics:get_exemplar(#{'__name__' => <<"g">>, h => <<"1">>, i => <<"2">>})),
+    ?_assertMatch({4, #{}, 978307200}, imetrics:get_exemplar(#{'__name__' => <<"g">>, h => <<"2">>})),
     Test7Map = #{j => <<"bb">>},
-    ?_assertMatch({5, Test7Map, 1009843200}, imetrics:get_exemplar(#{<<"__name__">> => <<"i">>})),
+    ?_assertMatch({5, Test7Map, 1009843200}, imetrics:get_exemplar(#{'__name__' => <<"i">>})),
     Test8Map = #{m => <<"cc">>},
-    ?_assertMatch({6, Test8Map, 1577836800}, imetrics:get_exemplar(#{<<"__name__">> => <<"k">>, l => <<"3">>})),
+    ?_assertMatch({6, Test8Map, 1577836800}, imetrics:get_exemplar(#{'__name__' => <<"k">>, l => <<"3">>})),
     
     ?_assertEqual(true, imetrics:set_exemplar(k, #{l => 3}, 0.1, 1893456000)),
     imetrics:set_exemplar(k, #{l => 3}, 0.1, 1893456000),
-    ?_assertMatch({0.1, #{}, 1893456000}, imetrics:get_exemplar(#{<<"__name__">> => <<"k">>, l => <<"3">>})),
+    ?_assertMatch({0.1, #{}, 1893456000}, imetrics:get_exemplar(#{'__name__' => <<"k">>, l => <<"3">>})),
 
-    ?_assertMatch({1, #{}, _}, imetrics:get_exemplar(#{name => <<"test1">>, <<"__name__">> => <<"l">>})),
-    ?_assertMatch({2, #{}, _}, imetrics:get_exemplar(#{name => <<"test2">>, <<"__name__">> => <<"l">>})).
+    ?_assertMatch({1, #{}, _}, imetrics:get_exemplar(#{name => <<"test1">>, '__name__' => <<"l">>})),
+    ?_assertMatch({2, #{}, _}, imetrics:get_exemplar(#{name => <<"test2">>, '__name__' => <<"l">>})).
 
 
 %% get tests

--- a/test/imetrics_tests.erl
+++ b/test/imetrics_tests.erl
@@ -123,23 +123,28 @@ exemplar_test(_Fixture) ->
     imetrics:set_exemplar(g, #{h => 2}, 4, 978307200),
     imetrics:set_exemplar(i, 5, #{j => "bb"}, 1009843200),
     imetrics:set_exemplar(k, #{l => 3}, 6, #{m => "cc"}, 1577836800),
+    imetrics:set_exemplar(l, #{name => "test1"}, 1),
+    imetrics:set_exemplar(l, #{name => "test2"}, 2),
 
-    ?_assertMatch({1, #{}, _}, imetrics:get_exemplar(#{name => <<"a">>})),
-    ?_assertMatch({2, #{}, _}, imetrics:get_exemplar(#{name => <<"b">>, c => <<"1">>})),
+    ?_assertMatch({1, #{}, _}, imetrics:get_exemplar(#{<<"__name__">> => <<"a">>})),
+    ?_assertMatch({2, #{}, _}, imetrics:get_exemplar(#{<<"__name__">> => <<"b">>, c => <<"1">>})),
     Test3Map = #{d => <<"2">>, e => <<"aa">>},
-    ?_assertMatch({2, Test3Map, _}, imetrics:get_exemplar(#{name => <<"c">>})),
-    ?_assertMatch({3, #{}, 946684800}, imetrics:get_exemplar(#{name => <<"f">>})),
+    ?_assertMatch({2, Test3Map, _}, imetrics:get_exemplar(#{<<"__name__">> => <<"c">>})),
+    ?_assertMatch({3, #{}, 946684800}, imetrics:get_exemplar(#{<<"__name__">> => <<"f">>})),
     Test5Map = #{j => <<"k">>},
-    ?_assertMatch({3, Test5Map, _}, imetrics:get_exemplar(#{name => <<"g">>, h => <<"1">>, i => <<"2">>})),
-    ?_assertMatch({4, #{}, 978307200}, imetrics:get_exemplar(#{name => <<"g">>, h => <<"2">>})),
+    ?_assertMatch({3, Test5Map, _}, imetrics:get_exemplar(#{<<"__name__">> => <<"g">>, h => <<"1">>, i => <<"2">>})),
+    ?_assertMatch({4, #{}, 978307200}, imetrics:get_exemplar(#{<<"__name__">> => <<"g">>, h => <<"2">>})),
     Test7Map = #{j => <<"bb">>},
-    ?_assertMatch({5, Test7Map, 1009843200}, imetrics:get_exemplar(#{name => <<"i">>})),
+    ?_assertMatch({5, Test7Map, 1009843200}, imetrics:get_exemplar(#{<<"__name__">> => <<"i">>})),
     Test8Map = #{m => <<"cc">>},
-    ?_assertMatch({6, Test8Map, 1577836800}, imetrics:get_exemplar(#{name => <<"k">>, l => <<"3">>})),
+    ?_assertMatch({6, Test8Map, 1577836800}, imetrics:get_exemplar(#{<<"__name__">> => <<"k">>, l => <<"3">>})),
     
     ?_assertEqual(true, imetrics:set_exemplar(k, #{l => 3}, 0.1, 1893456000)),
     imetrics:set_exemplar(k, #{l => 3}, 0.1, 1893456000),
-    ?_assertMatch({0.1, #{}, 1893456000}, imetrics:get_exemplar(#{name => <<"k">>, l => <<"3">>})).
+    ?_assertMatch({0.1, #{}, 1893456000}, imetrics:get_exemplar(#{<<"__name__">> => <<"k">>, l => <<"3">>})),
+
+    ?_assertMatch({1, #{}, _}, imetrics:get_exemplar(#{name => <<"test1">>, <<"__name__">> => <<"l">>})),
+    ?_assertMatch({2, #{}, _}, imetrics:get_exemplar(#{name => <<"test2">>, <<"__name__">> => <<"l">>})).
 
 
 %% get tests


### PR DESCRIPTION
name was being used as a keyword to store the counter/gauge name for exemplars, so if users had a tag of name for one of these objects, that tag would be overwritten in storage and lookup. Changed keyword to <<"__name"__>> instead to avoid overriding user-defined tags as much as possible.