### PR TITLE
Limit bucket count, fix hist range constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ and an example.
 
 ### Histograms ###
 
-Histograms are a way to take a continuous set of data and turn it into discrete "buckets," counting the number of elements that occur in a given range. Any value must be able to be accepted by a histogram, so the minimum bucket will count any elements <= to the value stored, and an additional "infinite" bucket will be added on top of any defined buckets to capture any values greater than the maximum value defined. Buckets can be defined manually by providing a list of cutoffs, or generated automatically, with an even distribution, by providing a min, max, and number of buckets.
+Histograms are a way to take a continuous set of data and turn it into discrete "buckets," counting the number of elements that occur in a given range. Any value must be able to be accepted by a histogram, so the minimum bucket will count any elements <= to the value stored, and an additional "infinite" bucket will be added on top of any defined buckets to capture any values greater than the maximum value defined. Buckets can be defined manually by providing a list of cutoffs, or generated automatically, with an even distribution, by providing a min, max, and number of buckets. The maximum number of buckets a histogram can have is limited by an environment variable (see below).
 
 ```erlang
 %manually define bucket cutoffs
@@ -265,7 +265,8 @@ Configuration
 | `http_server_port`            | `8085`    | Listening port                                               |
 | `separator`                   | `<<"_">>` | binary string used to separate tuple elements for Name, Key  |
 | `strict_openmetrics_compat`   | `false`   | If set to `true`, metrics will only display on the old HTTP endpoint if they aren't compatible with the OpenMetrics endpoint. Metrics will only display on one endpoint or the other, never both. |
-| `openmetrics_exemplar_compat` | `false`   | If set to `true`, counters will display with _total appended to their end, and exemplars will be displayed for counters. When `false`, counters will not get the appended suffix, and exemplars will not be displayed. |
+| `openmetrics_exemplar_compat` | `false`   | If set to `true`, counters will display with _total appended to their end, and exemplars will be displayed for counters. When `false`, counters will not get the appended suffix, and exemplars will not be displayed on counters. |
+| `hist_max_buckets`            | `64`      | Upper limit on the number of buckets for histograms. Calls to create a histogram with more buckets than this value will fail. |
 
 ## OpenMetrics conversion
 

--- a/src/imetrics_ets_owner.erl
+++ b/src/imetrics_ets_owner.erl
@@ -31,7 +31,6 @@ init([]) ->
     ets:new(imetrics_gauges, [public, named_table]),
     ets:new(imetrics_map_keys, [public, named_table]),
     ets:new(imetrics_stats, [public, named_table]),
-    ets:new(imetrics_hist, [public, named_table]),
     ets:new(imetrics_hist_openmetrics, [public, named_table]),
     ets:new(imetrics_vm_metrics, [public, named_table]),
     ets:new(imetrics_exemplars, [public, named_table]),

--- a/test/imetrics_hist_openmetrics_tests.erl
+++ b/test/imetrics_hist_openmetrics_tests.erl
@@ -25,12 +25,16 @@ new_test(_Fixture) ->
         ?_assertEqual(true, imetrics_hist_openmetrics:new(longer_list, [0, 0.001, 0.005, 0.01, 0.05, 0.1, 0.2, 0.4, 1, 3, 10, 100, 100000])),
         ?_assertEqual(true, imetrics_hist_openmetrics:new(multiple_tags, #{test_tag => "test_value", another_test_tag => "another_test_value"}, [0,1,2])),
         ?_assertEqual(true, imetrics_hist_openmetrics:new(single_range, [0,0], 1)),
-        ?_assertEqual(true, imetrics_hist_openmetrics:new(larger_range, [0,1000], 101)),
-        ?_assertEqual(true, imetrics_hist_openmetrics:new(decimal_range, [0, 1], 1001)),
         ?_assertEqual(true, imetrics_hist_openmetrics:new(empty_range, [0,0], 0)),
         ?_assertEqual(true, imetrics_hist_openmetrics:new(larger_empty_range, [0,100], 0)),
         ?_assertEqual({error, {badarith, check_inputs}}, imetrics_hist_openmetrics:new(illegal_range, [0,1], 1)),
-        ?_assertEqual({error, {badarith, check_inputs}}, imetrics_hist_openmetrics:new(zero_range, [0,0], 2))
+        ?_assertEqual({error, {badarith, check_inputs}}, imetrics_hist_openmetrics:new(zero_range, [0,0], 2)),
+
+        ?_assertEqual({error, {badarg, check_ets}}, imetrics_hist_openmetrics:new(oversize_range, [0, 1], 65)),
+        ?_assertEqual(ok, application:set_env(imetrics, hist_max_buckets, 8)),
+        ?_assertEqual({error, {badarg, check_ets}}, imetrics_hist_openmetrics:new(oversize_dynamic, [1, 2, 3, 4, 5, 6, 7, 8, 9])),
+        ?_assertEqual(ok, application:set_env(imetrics, hist_max_buckets, 64)),
+        ?_assertEqual(true, imetrics_hist_openmetrics:new(oversize_dynamic, [1, 2, 3, 4, 5, 6, 7, 8, 9]))
     ].
 
 add_test_() ->
@@ -69,7 +73,6 @@ get_test_() ->
 
 get_test(_Fixture) ->
     [
-        %doesn't test get_hist(Identifier) explicitly, as it's called by get_all(), and it isn't expected to be called by users directly.
         ?_assertEqual(true, imetrics_hist_openmetrics:new(simple, [0])),
         ?_assertEqual([{#{le => <<"0">>}, 0},{#{le => <<"+Inf">>}, 0}], imetrics_hist_openmetrics:get_hist(simple)),
         ?_assertEqual([], imetrics_hist_openmetrics:get_hist(fake_hist)),
@@ -115,7 +118,7 @@ get_test(_Fixture) ->
         ?_assertEqual({3,1}, imetrics_hist_openmetrics:add(tagged, #{tag => "one"}, 2)),
         ?_assertEqual({3,2}, imetrics_hist_openmetrics:add(tagged, #{tag => "one"}, 2)),
         ?_assertEqual({4,1}, imetrics_hist_openmetrics:add(tagged, #{tag => "one"}, 5)),
-                ?_assertEqual([{<<"tagged">>,
+        ?_assertEqual([{<<"tagged">>,
                         [{#{le => <<"1">>, tag => <<"two">>}, 0},
                         {#{le => <<"1.01">>, tag => <<"two">>}, 0},
                         {#{le => <<"1.1">>, tag => <<"two">>}, 0},
@@ -129,7 +132,38 @@ get_test(_Fixture) ->
                         {#{le => <<"+Inf">>, tag => <<"one">>}, 4}]},
                        {<<"simple">>,
                         [{#{le => <<"0">>}, 1},
-                        {#{le => <<"+Inf">>}, 2}]}], imetrics_hist_openmetrics:get_all())
+                        {#{le => <<"+Inf">>}, 2}]}], imetrics_hist_openmetrics:get_all()),
+        ?_assertEqual(true, imetrics_hist_openmetrics:new(range, [15, 20], 6)),
+        ?_assertEqual([{#{le => <<"15">>}, 0},
+                       {#{le => <<"16.0">>}, 0},
+                       {#{le => <<"17.0">>}, 0},
+                       {#{le => <<"18.0">>}, 0},
+                       {#{le => <<"19.0">>}, 0},
+                       {#{le => <<"20">>}, 0},
+                       {#{le => <<"+Inf">>}, 0}], imetrics_hist_openmetrics:get_hist(range)),
+        ?_assertEqual(true, imetrics_hist_openmetrics:new(large_range, [0, 1], 21)),
+        ?_assertEqual([{#{le => <<"0">>},0},
+                       {#{le => <<"0.049999999999999684">>},0},
+                       {#{le => <<"0.09999999999999969">>},0},
+                       {#{le => <<"0.1499999999999997">>},0},
+                       {#{le => <<"0.19999999999999968">>},0},
+                       {#{le => <<"0.24999999999999967">>},0},
+                       {#{le => <<"0.29999999999999966">>},0},
+                       {#{le => <<"0.34999999999999964">>},0},
+                       {#{le => <<"0.39999999999999963">>},0},
+                       {#{le => <<"0.4499999999999996">>},0},
+                       {#{le => <<"0.4999999999999996">>},0},
+                       {#{le => <<"0.5499999999999996">>},0},
+                       {#{le => <<"0.5999999999999996">>},0},
+                       {#{le => <<"0.6499999999999997">>},0},
+                       {#{le => <<"0.6999999999999997">>},0},
+                       {#{le => <<"0.7499999999999998">>},0},
+                       {#{le => <<"0.7999999999999998">>},0},
+                       {#{le => <<"0.8499999999999999">>},0},
+                       {#{le => <<"0.8999999999999999">>},0},
+                       {#{le => <<"0.95">>},0},
+                       {#{le => <<"1">>},0},
+                       {#{le => <<"+Inf">>},0}], imetrics_hist_openmetrics:get_hist(large_range))
     ].
 
 exemplar_test_() ->

--- a/test/imetrics_tests.erl
+++ b/test/imetrics_tests.erl
@@ -310,7 +310,7 @@ http_test_openmetrics(#{port := Port}) ->
         "stats{map_key=\"sum\"} 10",
         "stats{map_key=\"sum2\"} 100",
         "# TYPE tagged_hist histogram",
-        "tagged_hist_bucket{hist_tag=\"two\",le=\"0.0\"} 0",
+        "tagged_hist_bucket{hist_tag=\"two\",le=\"0\"} 0",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"0.5\"} 0",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"1.0\"} 0",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"1.5\"} 0",
@@ -332,7 +332,7 @@ http_test_openmetrics(#{port := Port}) ->
         "tagged_hist_bucket{hist_tag=\"two\",le=\"9.5\"} 1",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"10\"} 1",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"+Inf\"} 1",
-        "tagged_hist_bucket{hist_tag=\"one\",le=\"0.0\"} 0",
+        "tagged_hist_bucket{hist_tag=\"one\",le=\"0\"} 0",
         "tagged_hist_bucket{hist_tag=\"one\",le=\"0.25\"} 0",
         "tagged_hist_bucket{hist_tag=\"one\",le=\"0.5\"} 1",
         "tagged_hist_bucket{hist_tag=\"one\",le=\"0.75\"} 1 # {} 0.58 946684800",
@@ -399,7 +399,7 @@ http_test_openmetrics_strict(#{port := Port}) ->
         "# TYPE mapped_gauge gauge",
         "mapped_gauge{key=\"value\"} 1.5",
         "# TYPE tagged_hist histogram",
-        "tagged_hist_bucket{hist_tag=\"two\",le=\"0.0\"} 0",
+        "tagged_hist_bucket{hist_tag=\"two\",le=\"0\"} 0",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"0.5\"} 0",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"1.0\"} 0",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"1.5\"} 0",
@@ -421,7 +421,7 @@ http_test_openmetrics_strict(#{port := Port}) ->
         "tagged_hist_bucket{hist_tag=\"two\",le=\"9.5\"} 1",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"10\"} 1",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"+Inf\"} 1",
-        "tagged_hist_bucket{hist_tag=\"one\",le=\"0.0\"} 0",
+        "tagged_hist_bucket{hist_tag=\"one\",le=\"0\"} 0",
         "tagged_hist_bucket{hist_tag=\"one\",le=\"0.25\"} 0",
         "tagged_hist_bucket{hist_tag=\"one\",le=\"0.5\"} 1",
         "tagged_hist_bucket{hist_tag=\"one\",le=\"0.75\"} 1 # {} 0.58 946684800",
@@ -474,7 +474,7 @@ http_test_openmetrics_exemplars(#{port := Port}) ->
         "# TYPE mapped_gauge gauge",
         "mapped_gauge{key=\"value\"} 1.5",
         "# TYPE tagged_hist histogram",
-        "tagged_hist_bucket{hist_tag=\"two\",le=\"0.0\"} 0",
+        "tagged_hist_bucket{hist_tag=\"two\",le=\"0\"} 0",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"0.5\"} 0",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"1.0\"} 0",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"1.5\"} 0",
@@ -496,7 +496,7 @@ http_test_openmetrics_exemplars(#{port := Port}) ->
         "tagged_hist_bucket{hist_tag=\"two\",le=\"9.5\"} 1",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"10\"} 1",
         "tagged_hist_bucket{hist_tag=\"two\",le=\"+Inf\"} 1",
-        "tagged_hist_bucket{hist_tag=\"one\",le=\"0.0\"} 0",
+        "tagged_hist_bucket{hist_tag=\"one\",le=\"0\"} 0",
         "tagged_hist_bucket{hist_tag=\"one\",le=\"0.25\"} 0",
         "tagged_hist_bucket{hist_tag=\"one\",le=\"0.5\"} 1",
         "tagged_hist_bucket{hist_tag=\"one\",le=\"0.75\"} 1 # {} 0.58 946684800",
@@ -535,12 +535,12 @@ ticktock_test(_Fixture) ->
     [
         ?_assertEqual({15, 1}, (fun() ->
                     Tick = imetrics:tick(test, millisecond),
-                    timer:sleep(285),
+                    timer:sleep(284),
                     imetrics:tock(Tick)
             end)()),
         ?_assertEqual({15, 1}, (fun() ->
                     Tick = imetrics:tick(test, millisecond),
-                    timer:sleep(285),
+                    timer:sleep(284),
                     imetrics:tock_as(Tick, test2)
             end)())
     ].
@@ -555,14 +555,14 @@ ticktock_s_test(_Fixture) ->
     [
      ?_assertMatch({15, 1}, (fun() ->
                                      {Ref, Ticks} = imetrics:tick_s(#{}, test, millisecond),
-                                     timer:sleep(285),
+                                     timer:sleep(284),
                                      {Result, Ticks2} = imetrics:tock_s(Ticks, Ref),
                                      0 = map_size(Ticks2),
                                      Result
                              end)()),
      ?_assertMatch({15, 2}, (fun() ->
                                      {_Ref, Ticks} = imetrics:tick_s(#{}, test, millisecond),
-                                     timer:sleep(285),
+                                     timer:sleep(284),
                                      {Result, Ticks2} = imetrics:tock_s(Ticks, test),
                                      0 = map_size(Ticks2),
                                      Result


### PR DESCRIPTION
Added an environment variable to limit the maximum number of buckets allowed in a histogram as a failsafe if people unintentionally create massive histograms, mostly useful to prevent cost blowups as each bucket is considered a separate time series. Additionally, discovered and fixed a bug with the range based constructor for histograms where 1. the min bucket would sometimes not be created due to floating point errors, and 2. more buckets would sometimes be generated than intended. Added/modified tests to account for both the new feature and the bug fix.