### PR TITLE
tock functions return the diff value to be used as exemplar values by caller

### DIFF
--- a/src/imetrics.erl
+++ b/src/imetrics.erl
@@ -193,7 +193,8 @@ tock(Tick, Fun) ->
 tock_as(Tick, NewName) ->
     tock_as(Tick, NewName,
             fun(Name, Diff) ->
-                    imetrics_hist_openmetrics:add(Name, Diff)
+                    imetrics_hist_openmetrics:add(Name, Diff),
+                    Diff
             end).
 
 tock_as({Name, Unit, Ts}, '_', Fun) when is_function(Fun) ->

--- a/test/imetrics_tests.erl
+++ b/test/imetrics_tests.erl
@@ -527,20 +527,20 @@ ticktock_test_() ->
 
 start_ticktock() ->
     F = start(),
-    imetrics:hist(test, [0, 1000], 50),
-    imetrics:hist(test2, [0, 1000], 50),
+    imetrics:hist(test, [1, 10]),
+    imetrics:hist(test2, [1, 10]),
     F.
 
 ticktock_test(_Fixture) ->
     [
-        ?_assertEqual({15, 1}, (fun() ->
-                    Tick = imetrics:tick(test, millisecond),
-                    timer:sleep(284),
+        ?_assertEqual(0, (fun() ->
+                    Tick = imetrics:tick(test, second),
+                    timer:sleep(5),
                     imetrics:tock(Tick)
             end)()),
-        ?_assertEqual({15, 1}, (fun() ->
-                    Tick = imetrics:tick(test, millisecond),
-                    timer:sleep(284),
+        ?_assertEqual(0, (fun() ->
+                    Tick = imetrics:tick(test, second),
+                    timer:sleep(5),
                     imetrics:tock_as(Tick, test2)
             end)())
     ].
@@ -553,16 +553,16 @@ ticktock_s_test_() ->
 
 ticktock_s_test(_Fixture) ->
     [
-     ?_assertMatch({15, 1}, (fun() ->
-                                     {Ref, Ticks} = imetrics:tick_s(#{}, test, millisecond),
-                                     timer:sleep(284),
+     ?_assertMatch(0, (fun() ->
+                                     {Ref, Ticks} = imetrics:tick_s(#{}, test, second),
+                                     timer:sleep(5),
                                      {Result, Ticks2} = imetrics:tock_s(Ticks, Ref),
                                      0 = map_size(Ticks2),
                                      Result
                              end)()),
-     ?_assertMatch({15, 2}, (fun() ->
-                                     {_Ref, Ticks} = imetrics:tick_s(#{}, test, millisecond),
-                                     timer:sleep(284),
+     ?_assertMatch(0, (fun() ->
+                                     {_Ref, Ticks} = imetrics:tick_s(#{}, test, second),
+                                     timer:sleep(5),
                                      {Result, Ticks2} = imetrics:tock_s(Ticks, test),
                                      0 = map_size(Ticks2),
                                      Result


### PR DESCRIPTION
For histograms, I think a natural 'exemplar value' is the actual duration measured. Our apps tend to use the 'tick/tock' functions for histogram tracking, and the duration value is not currently exposed by the API. This change exposes the duration value so that it can be used elsewhere (like an exemplar)