### PR TITLE
Support OpenMetrics Info, set_exemplar Histogram Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,23 @@ If exemplars are not updated between queries, additional copies of the exemplar 
 so creating exemplars on infrequent events will not result in overpopulation of the data set.
 Additionally, whenever `set_exemplar` is called, the previous exemplar associated with the given
 name and tags will be overwritten, meaning only the most recently passed exemplar will be stored at any given time.
-`imetrics:set_exemplar` does not check to see if the added exemplar is associated with any actual values, and will always return true. `imetrics_hist_openmetrics:set_exemplar`, the function for adding exemplars to histograms works slightly differently, in that the value provided for the exemplar determines which bucket it is associated with in the histogram, and if the function is called for a histogram/tag combination that does not exist, this function will return `{error, {badarg, check_ets}}`.
+`imetrics:set_exemplar`, when called without a type identifier, or when called with a type of `counter`, does not check to see if the added exemplar is associated with any actual values, and will always return true. `imetrics_hist_openmetrics:set_exemplar`, or `imetrics:set_exemplar` with type `histogram`, works slightly differently, in that the value provided for the exemplar determines which bucket it is associated with in the histogram, and if the function is called for a histogram/tag combination that does not exist, this function will return `{error, {badarg, check_ets}}`.
 ```erlang
 %Minimal set_exemplar
 imetrics:set_exemplar(http_responses, 1),
 %set_exemplar with all details included
-imetrics:set_exemplar(http_responses, #{ code => "404" }, 1, #{traceid => "oHg5SJYRHA0"}, 1684267027.342),
+imetrics:set_exemplar(http_responses, #{ code => "404" }, 1, #{traceid => "oHg5SJYRHA0"}, 1684267027.342, counter),
 
 %Setting an exemplar on a histogram:
-imetrics_hist_openmetrics:set_exemplar(http_response_times, #{code => "408"}, 15.3).
+imetrics_hist_openmetrics:set_exemplar(http_response_times, #{code => "408"}, 15.3),
+imetrics:set_exemplar(http_response_times, #{code => "400"}, 23, histogram).
+```
+
+### Info ###
+The OpenMetrics standard specifies the Info type as a way to expose textual information that is expected to remain constant while a program is running, for example, a version number, a revision control commit, or a compiler version. imetrics supports info metrics with the `set_info` function, which takes two arguments: a Name, and a map of tags to represent the data to be exposed. Info metrics are unique based on Name, so any time `set_info` is called for a given name, the previous entry bearing that name will be overwritten with the new map.
+
+```erlang
+imetrics:set_info(server, #{version => "1.7.10", otp => "25.2"}).
 ```
 
 ### Allowed types ###

--- a/src/imetrics_ets_owner.erl
+++ b/src/imetrics_ets_owner.erl
@@ -34,6 +34,7 @@ init([]) ->
     ets:new(imetrics_hist_openmetrics, [public, named_table]),
     ets:new(imetrics_vm_metrics, [public, named_table]),
     ets:new(imetrics_exemplars, [public, named_table]),
+    ets:new(imetrics_info, [public, named_table]),
 
     {ok, #{  }}.
 

--- a/src/openmetrics.erl
+++ b/src/openmetrics.erl
@@ -44,6 +44,8 @@ deliver_metricfamily(Req, {Name, {Type, MetricValue}}) ->
                 cowboy_req:stream_body(["# TYPE ", Name, " gauge\n"], nofin, Req);
             {histogram, _} ->
                 cowboy_req:stream_body(["# TYPE ", Name, " histogram\n"], nofin, Req);
+            {info, _} ->
+                cowboy_req:stream_body(["# TYPE ", Name, " info\n"], nofin, Req);
             {_, false} ->
                 cowboy_req:stream_body(["# TYPE ", Name, " unknown\n"], nofin, Req);
             {_, true} ->
@@ -108,6 +110,8 @@ deliver_mapped_metric(Req, Type, Name, [{Tags, Value} | Tail]) ->
             cowboy_req:stream_body([Name, "_total", TagString, " ", strnum(Value), get_exemplar_string(Name, Tags), "\n"], nofin, Req);
         {histogram, _} ->
             cowboy_req:stream_body([Name, "_bucket", TagString, " ", strnum(Value), get_exemplar_string(Name, Tags), "\n"], nofin, Req);
+        {info, _} ->
+            cowboy_req:stream_body([Name, "_info", TagString, " ", strnum(Value), "\n"], nofin, Req);
         {_, _} ->
             cowboy_req:stream_body([Name, TagString, " ", strnum(Value), "\n"], nofin, Req)
     end,

--- a/test/imetrics_tests.erl
+++ b/test/imetrics_tests.erl
@@ -97,6 +97,21 @@ badarg_test(_Fixture) ->
         ?_assertEqual({error,{badarg,check_ets}}, imetrics:set_gauge_m(atom_gm, k, 1.5))
     ].
 
+info_test_() ->
+    {setup, fun start/0,
+        fun stop/1,
+        fun info_test/1}.
+
+info_test(_Fixture) ->
+    [
+        ?_assertEqual(true, imetrics:set_info(empty_map, #{})),
+        ?_assertEqual(true, imetrics:set_info(simple_map, #{elem_1 => val_1})),
+        ?_assertEqual(true, imetrics:set_info(simple_map, #{elem_1 => val_2})),
+        ?_assertEqual([{<<"empty_map">>, {info, [{#{}, 1}]}}, {<<"simple_map">>, {info, [{#{elem_1 => <<"val_2">>}, 1}]}}], imetrics:get_with_types()),
+        ?_assertEqual(true, imetrics:set_info(simple_map, #{elem_1 => val_3, elem_2 => val_1})),
+        ?_assertEqual([{<<"empty_map">>, {info, [{#{}, 1}]}}, {<<"simple_map">>, {info, [{#{elem_1 => <<"val_3">>, elem_2 => <<"val_1">>}, 1}]}}], imetrics:get_with_types())
+    ].
+
 %%exemplar tests
 exemplar_test_() ->
     {setup,


### PR DESCRIPTION
Add set_info/2, as well as related structure in existing functions, to support OpenMetrics info metrics with unique names. Modified imetrics:set_exemplar to have more function variants to account for a Type argument, which assumes counter but can be specified to be histogram as an alternative to calling imetrics_hist_openmetrics:set_exemplar. Currently supported types are histogram and counter, as limited by OpenMetrics.