### PR TITLE
Fix bug with registered names

### DIFF
--- a/src/imetrics.erl
+++ b/src/imetrics.erl
@@ -341,7 +341,7 @@ call_metrics_fun(Name, Fun, Default) ->
     after 5000 ->
         add(imetrics_metric_fun_timeout, #{ metric => Name }),
         Default
-    end
+    end.
 
 get_unmapped(T) ->
     Acc = ets:foldl(fun({Name, Value}, Acc0) ->

--- a/src/imetrics.erl
+++ b/src/imetrics.erl
@@ -341,7 +341,7 @@ call_metrics_fun(Name, Fun, Default) ->
     after 5000 ->
         add(imetrics_metric_fun_timeout, #{ metric => Name }),
         Default
-    end.
+    end
 
 get_unmapped(T) ->
     Acc = ets:foldl(fun({Name, Value}, Acc0) ->


### PR DESCRIPTION
When a process with a registered name was the process with the largest memory or message queue on a system, the presence of the registered name as an atom (added in `imetrics_vm_metrics:proc_attrs/2`) broke the pattern match in `imetrics_vm_metrics:metric_fun/0`.

To fix this:
- I updated `proc_attrs/2` to include the registered name in the standard proplists format (even if it was technically a compliant proplist before)
- I updated the pattern match in `metric_fun` to be more forgiving, and match the proplist to a single variable, invariant of key ordering
- I added calls to `proplists:get_value/3` so missing information can now be supplanted by default values.
- I also updated the format specifiers in the log message from `~p` to `~w` for most of the values, so no newlines are present in the log message.