### PR TITLE
Fixes a bug with asynchronous metric fun evaluation

### DIFF
--- a/src/imetrics.erl
+++ b/src/imetrics.erl
@@ -326,7 +326,8 @@ call_metrics_fun(Name, Fun, Default) ->
     % to ensure we can continue if it doesn't return its
     % value in a reasonable time
     ParentPid = self(),
-    ChildPid = spawn_link(fun() ->
+    Ref = make_ref(),
+    spawn_link(fun() ->
         ReturnValue = try
             Fun()
         catch _:_ ->
@@ -334,20 +335,14 @@ call_metrics_fun(Name, Fun, Default) ->
             Default
         end,
 
-        % before we send our result, make sure we haven't been terminated
-        receive
-            {metrics_abort, timeout} -> noop
-        after 0 ->
-            ParentPid ! {metrics_fun, ReturnValue, self()}
-        end
+        ParentPid ! {Ref, metrics_fun, ReturnValue}
     end),
 
     % wait for the function to return
     receive
-        {metrics_fun, Result, ChildPid} -> Result
+        {Ref, metrics_fun, Result} -> Result
     % after 5 seconds, return the default value and signal to cancel the request
     after 5000 ->
-        ChildPid ! {metrics_abort, timeout},
         add(imetrics_metric_fun_timeout, #{ metric => Name }),
         Default
     end.

--- a/src/imetrics.erl
+++ b/src/imetrics.erl
@@ -332,7 +332,7 @@ call_metrics_fun(Name, Fun, Default) ->
         catch _:_ ->
             add(imetrics_metric_fun_error, #{ metric => Name }),
             Default
-        end
+        end,
 
         % before we send our result, make sure we haven't been terminated
         receive

--- a/src/imetrics_sup.erl
+++ b/src/imetrics_sup.erl
@@ -33,6 +33,12 @@ init([]) ->
                        shutdown => infinity,
                        type => supervisor,
                        modules => [imetrics_actors_guild_sup]},
+    VMMetricsSup = #{id => imetrics_vm_metrics_sup,
+                     start => {imetrics_vm_metrics, start_link, []},
+                     restart => permanent,
+                     shutdown => 5000,
+                     type => worker,
+                     modules => [imetrics_vm_metrics]},
     HttpSpecs = case application:get_env(imetrics, require_http_server_on_startup) of
                     {ok, false} ->
                         [];
@@ -44,7 +50,7 @@ init([]) ->
                           type => worker,
                           modules => [imetrics_http_server]}]
                 end,
-    ChildSpecs = [EtsOwner, ActorsGuildSup] ++ HttpSpecs,
+    ChildSpecs = [EtsOwner, ActorsGuildSup, VMMetricsSup] ++ HttpSpecs,
     {ok, {SupFlags, ChildSpecs}}.
 
 slo_info() ->

--- a/src/imetrics_vm_metrics.erl
+++ b/src/imetrics_vm_metrics.erl
@@ -1,73 +1,101 @@
 -module(imetrics_vm_metrics).
+-behavior(gen_server).
+-export([start_link/0]).
+-export([init/1, handle_cast/2, handle_call/3, handle_info/2, terminate/2, code_change/3]).
 -export([install/0, proc_count/2]).
+-define(RefreshInterval, 60000). % 60 seconds
 
-install() ->
-    imetrics:set_multigauge(erlang_vm, vm_metric, fun metric_fun/0).
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
-metric_fun() ->
-    LastUpdateTime = case ets:lookup(imetrics_vm_metrics, last_update_time) of
-        [{last_update_time, T}] -> T;
-        [] -> {0,0,0}
-    end,
+init(_) ->
+    State = #{
+        installed => false
+    },
+    {ok, State}.
 
-    Table = case (timer:now_diff(erlang:timestamp(), LastUpdateTime) div 1000) > timer:seconds(55) of
+handle_cast(refresh_gauges, State) ->
+    [
+        [{MaxMQueuePid, MaxMQueueLen, MaxMQueueProps}|_],
+        [{MaxMemoryPid, MaxMemory, MaxMemoryProps}|_]
+    ] = proc_count([
+        message_queue_len,
+        memory
+    ], 1),
+
+    % if the memory is > 512MB, log the PID to console
+    case MaxMemory > 512000000 of
         true ->
-            [
-                [{MaxMQueuePid, MaxMQueueLen, MaxMQueueProps}|_],
-                [{MaxMemoryPid, MaxMemory, MaxMemoryProps}|_]
-            ] = proc_count([
-                message_queue_len,
-                memory
-            ], 1),
-
-            % if the memory is > 512MB, log the PID to console
-            case MaxMemory > 512000000 of
-                true ->
-                    MaxMemoryCurrentFunc = proplists:get_value(current_function, MaxMemoryProps, unknown_current_function),
-                    MaxMemoryInitialCall = proplists:get_value(initial_call, MaxMemoryProps, unknown_initial_call),
-                    MaxMemoryRegisteredName = proplists:get_value(registered_name, MaxMemoryProps, unknown_registered_name),
-                    logger:info("Max Memory PID: ~p, current_function: ~w, registered_name: ~w, initial_call: ~w", [
-                        MaxMemoryPid,
-                        MaxMemoryCurrentFunc,
-                        MaxMemoryRegisteredName,
-                        MaxMemoryInitialCall
-                    ]);
-                false ->
-                    noop
-            end,
-
-            % if a process has more than 50 messages, log the PID
-            case MaxMQueueLen > 50 of
-                true ->
-                    MaxMQueueCurrentFunc = proplists:get_value(current_function, MaxMQueueProps, unknown_current_function),
-                    MaxMQueueInitialCall = proplists:get_value(initial_call, MaxMQueueProps, unknown_initial_call),
-                    MaxMQueueRegisteredName = proplists:get_value(registered_name, MaxMQueueProps, unknown_registered_name),
-                    logger:info("Max Message Queue PID: ~p, current_function: ~w, registered_name: ~w, initial_call: ~w", [
-                        MaxMQueuePid,
-                        MaxMQueueCurrentFunc,
-                        MaxMQueueRegisteredName,
-                        MaxMQueueInitialCall
-                    ]);
-                false ->
-                    noop
-            end,
-
-            Objects = [
-                {max_message_queue_len, MaxMQueueLen},
-                {max_memory, MaxMemory},
-                {atom_count, erlang:system_info(atom_count)},
-                {atom_limit, erlang:system_info(atom_limit)},
-                {process_count, erlang:system_info(process_count)},
-                {last_update_time, erlang:timestamp()}
-            ],
-            ets:insert(imetrics_vm_metrics, Objects),
-            Objects;
+            MaxMemoryCurrentFunc = proplists:get_value(current_function, MaxMemoryProps, unknown_current_function),
+            MaxMemoryInitialCall = proplists:get_value(initial_call, MaxMemoryProps, unknown_initial_call),
+            MaxMemoryRegisteredName = proplists:get_value(registered_name, MaxMemoryProps, unknown_registered_name),
+            logger:info("Max Memory PID: ~p, current_function: ~w, registered_name: ~w, initial_call: ~w", [
+                MaxMemoryPid,
+                MaxMemoryCurrentFunc,
+                MaxMemoryRegisteredName,
+                MaxMemoryInitialCall
+            ]);
         false ->
-            ets:tab2list(imetrics_vm_metrics)
+            noop
     end,
 
-    Metrics = lists:keydelete(last_update_time, 1, Table),
-    Metrics.
+    % if a process has more than 50 messages, log the PID
+    case MaxMQueueLen > 50 of
+        true ->
+            MaxMQueueCurrentFunc = proplists:get_value(current_function, MaxMQueueProps, unknown_current_function),
+            MaxMQueueInitialCall = proplists:get_value(initial_call, MaxMQueueProps, unknown_initial_call),
+            MaxMQueueRegisteredName = proplists:get_value(registered_name, MaxMQueueProps, unknown_registered_name),
+            logger:info("Max Message Queue PID: ~p, current_function: ~w, registered_name: ~w, initial_call: ~w", [
+                MaxMQueuePid,
+                MaxMQueueCurrentFunc,
+                MaxMQueueRegisteredName,
+                MaxMQueueInitialCall
+            ]);
+        false ->
+            noop
+    end,
+
+    AtomCount = erlang:system_info(atom_count),
+    AtomLimit = erlang:system_info(atom_limit),
+    ProcessCount = erlang:system_info(process_count),
+
+    imetrics:set_gauge(erlang_vm, #{ vm_metric => max_message_queue_len }, MaxMQueueLen),
+    imetrics:set_gauge(erlang_vm, #{ vm_metric => max_memory }, MaxMemory),
+    imetrics:set_gauge(erlang_vm, #{ vm_metric => atom_count }, AtomCount),
+    imetrics:set_gauge(erlang_vm, #{ vm_metric => atom_limit }, AtomLimit),
+    imetrics:set_gauge(erlang_vm, #{ vm_metric => process_count }, ProcessCount),
+    imetrics:set_gauge(erlang_vm, #{ vm_metric => last_update_time }, erlang:timestamp()),
+
+    % recalculate after the interval time has passed
+    erlang:send_after(?RefreshInterval, self(), {'$gen_cast', refresh_gauges}),
+
+    % We don't need to reply nor update the state.
+    {noreply, State};
+% for any other casts, fail.
+handle_cast(_Cast, _State) ->
+    erlang:error(function_clause).
+
+% only allow the server to be "installed" once
+handle_call(install, _From, #{ installed := false }) ->
+    gen_server:cast(?MODULE, refresh_gauges),
+    {reply, ok, #{ installed => true }};
+handle_call(install, _From, State) ->
+    {reply, already_installed, State};
+handle_call(_Call, _From, _State) ->
+    erlang:error(function_clause).
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extras) ->
+    {ok, State}.
+
+% designed to be called only once
+install() ->
+    gen_server:call(?MODULE, install).
 
 % A modification of recon:proc_count that allows you to fetch multiple
 % attributes without calling process_info multiple times.


### PR DESCRIPTION
Values from some metrics may have been reported as belonging to other metrics. The `receive` loop now matches on pid to avoid this problem.