### PR TITLE
Upgrade recon dep

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,6 +3,6 @@
 ]}.
 {deps, [
     {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.8.0"}}},
-    {recon, {git, "https://github.com/ferd/recon.git", {tag, "2.5.1"}}}
+    {recon, {git, "https://github.com/ferd/recon.git", {tag, "2.5.6"}}}
 ]}.
 {shell, [{apps, [imetrics]}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -12,5 +12,5 @@
   1},
  {<<"recon">>,
   {git,"https://github.com/ferd/recon.git",
-       {ref,"f7b6c08e6e9e2219db58bfb012c58c178822e01e"}},
+       {ref,"c2a76855be3a226a3148c0dfc21ce000b6186ef8"}},
   0}].


### PR DESCRIPTION
The latest version is 4 years newer than the previous version and addresses some warnings when compiling with OTP 26.