### PR TITLE
Enable write concurrency on imetrics ETS tables

### DIFF
--- a/src/imetrics_ets_owner.erl
+++ b/src/imetrics_ets_owner.erl
@@ -27,6 +27,13 @@ start_link() ->
 %% ------------------------------------------------------------------
 
 init([]) ->
+    % imetrics' use case typically involves many more writes than reads. only one or two metrics collectors
+    % should be reading from imetrics, even in a large application... while many processes may be writing.
+    % 
+    % these tables are configured with `write_concurrency` to ensure that individual processes don't lock the
+    % whole table when they try to increase a metric. additionally, `decentralized_counters` helps distribute
+    % the ETS table accounting (total # of objects, table size) across multiple different schedulers so
+    % there's no single shared lock when inserting or deleting new metrics either.
     ets:new(imetrics_counters, [public, named_table, {write_concurrency, true}, {decentralized_counters, true}]),
     ets:new(imetrics_gauges, [public, named_table, {write_concurrency, true}, {decentralized_counters, true}]),
     ets:new(imetrics_map_keys, [public, named_table, {write_concurrency, true}, {decentralized_counters, true}]),

--- a/src/imetrics_ets_owner.erl
+++ b/src/imetrics_ets_owner.erl
@@ -27,14 +27,14 @@ start_link() ->
 %% ------------------------------------------------------------------
 
 init([]) ->
-    ets:new(imetrics_counters, [public, named_table]),
-    ets:new(imetrics_gauges, [public, named_table]),
-    ets:new(imetrics_map_keys, [public, named_table]),
-    ets:new(imetrics_stats, [public, named_table]),
-    ets:new(imetrics_hist_openmetrics, [public, named_table]),
-    ets:new(imetrics_vm_metrics, [public, named_table]),
-    ets:new(imetrics_exemplars, [public, named_table]),
-    ets:new(imetrics_info, [public, named_table]),
+    ets:new(imetrics_counters, [public, named_table, {write_concurrency, true}, {decentralized_counters, true}]),
+    ets:new(imetrics_gauges, [public, named_table, {write_concurrency, true}, {decentralized_counters, true}]),
+    ets:new(imetrics_map_keys, [public, named_table, {write_concurrency, true}, {decentralized_counters, true}]),
+    ets:new(imetrics_stats, [public, named_table, {write_concurrency, true}, {decentralized_counters, true}]),
+    ets:new(imetrics_hist_openmetrics, [public, named_table, {write_concurrency, true}, {decentralized_counters, true}]),
+    ets:new(imetrics_vm_metrics, [public, named_table, {write_concurrency, true}, {decentralized_counters, true}]),
+    ets:new(imetrics_exemplars, [public, named_table, {write_concurrency, true}, {decentralized_counters, true}]),
+    ets:new(imetrics_info, [public, named_table, {write_concurrency, true}, {decentralized_counters, true}]),
 
     {ok, #{  }}.
 

--- a/test/imetrics_tests.erl
+++ b/test/imetrics_tests.erl
@@ -117,9 +117,9 @@ info_test(_Fixture) ->
         ?_assertEqual(true, imetrics:set_info(empty_map, #{})),
         ?_assertEqual(true, imetrics:set_info(simple_map, #{elem_1 => val_1})),
         ?_assertEqual(true, imetrics:set_info(simple_map, #{elem_1 => val_2})),
-        ?_assertEqual([{<<"empty_map">>, {info, [{#{}, 1}]}}, {<<"simple_map">>, {info, [{#{elem_1 => <<"val_2">>}, 1}]}}], imetrics:get_with_types()),
+        ?_assertEqual([{<<"simple_map">>, {info, [{#{elem_1 => <<"val_2">>}, 1}]}}, {<<"empty_map">>, {info, [{#{}, 1}]}}], imetrics:get_with_types()),
         ?_assertEqual(true, imetrics:set_info(simple_map, #{elem_1 => val_3, elem_2 => val_1})),
-        ?_assertEqual([{<<"empty_map">>, {info, [{#{}, 1}]}}, {<<"simple_map">>, {info, [{#{elem_1 => <<"val_3">>, elem_2 => <<"val_1">>}, 1}]}}], imetrics:get_with_types())
+        ?_assertEqual([{<<"simple_map">>, {info, [{#{elem_1 => <<"val_3">>, elem_2 => <<"val_1">>}, 1}]}}, {<<"empty_map">>, {info, [{#{}, 1}]}}], imetrics:get_with_types())
     ].
 
 %%exemplar tests

--- a/test/imetrics_tests.erl
+++ b/test/imetrics_tests.erl
@@ -117,9 +117,9 @@ info_test(_Fixture) ->
         ?_assertEqual(true, imetrics:set_info(empty_map, #{})),
         ?_assertEqual(true, imetrics:set_info(simple_map, #{elem_1 => val_1})),
         ?_assertEqual(true, imetrics:set_info(simple_map, #{elem_1 => val_2})),
-        ?_assertEqual([{<<"simple_map">>, {info, [{#{elem_1 => <<"val_2">>}, 1}]}}, {<<"empty_map">>, {info, [{#{}, 1}]}}], imetrics:get_with_types()),
+        ?_assertEqual([{<<"empty_map">>, {info, [{#{}, 1}]}}, {<<"simple_map">>, {info, [{#{elem_1 => <<"val_2">>}, 1}]}}], lists:sort(imetrics:get_with_types())),
         ?_assertEqual(true, imetrics:set_info(simple_map, #{elem_1 => val_3, elem_2 => val_1})),
-        ?_assertEqual([{<<"simple_map">>, {info, [{#{elem_1 => <<"val_3">>, elem_2 => <<"val_1">>}, 1}]}}, {<<"empty_map">>, {info, [{#{}, 1}]}}], imetrics:get_with_types())
+        ?_assertEqual([{<<"empty_map">>, {info, [{#{}, 1}]}}, {<<"simple_map">>, {info, [{#{elem_1 => <<"val_3">>, elem_2 => <<"val_1">>}, 1}]}}], lists:sort(imetrics:get_with_types()))
     ].
 
 %%exemplar tests


### PR DESCRIPTION
#32 should merge first, then this diff will be much cleaner. This enables `{write_concurrency, true}` and `{decentralized_counters, true}` for all imetrics ETS tables.